### PR TITLE
Fix invalid SemVer

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,6 +44,6 @@
     "thallium": "*",
     "xradiation": "*",
     "cardinal-components-item": "<2.4.2",
-    "architectury": "1.2.72> <1.3.77"
+    "architectury": ">1.2.72 <1.3.77"
   }
 }


### PR DESCRIPTION
This fixes the following debug error log:

<details>
  <summary>Debug log</summary>

```
net.fabricmc.loader.api.VersionParsingException: Could not parse version number component '72>'!
	at net.fabricmc.loader.util.version.SemanticVersionImpl.<init>(SemanticVersionImpl.java:100)
	at net.fabricmc.loader.util.version.SemanticVersionPredicateParser.create(SemanticVersionPredicateParser.java:47)
	at net.fabricmc.loader.util.version.VersionPredicateParser.matches(VersionPredicateParser.java:36)
	at net.fabricmc.loader.metadata.ModDependencyImpl.matches(ModDependencyImpl.java:47)
	at net.fabricmc.loader.discovery.ModResolver.lambda$findCompatibleSet$3(ModResolver.java:192)
	at java.util.stream.ReferencePipeline$2$1.accept(Unknown Source)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)
	at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
	at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
	at java.util.stream.AbstractPipeline.evaluateToArrayNode(Unknown Source)
	at java.util.stream.IntPipeline.toArray(Unknown Source)
	at net.fabricmc.loader.discovery.ModResolver.findCompatibleSet(ModResolver.java:194)
	at net.fabricmc.loader.discovery.ModResolver.resolve(ModResolver.java:787)
	at net.fabricmc.loader.FabricLoader.setup(FabricLoader.java:211)
	at net.fabricmc.loader.FabricLoader.load(FabricLoader.java:201)
	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:126)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)
Caused by: java.lang.NumberFormatException: For input string: "72>"
	at java.lang.NumberFormatException.forInputString(Unknown Source)
	at java.lang.Integer.parseInt(Unknown Source)
	at java.lang.Integer.parseInt(Unknown Source)
	at net.fabricmc.loader.util.version.SemanticVersionImpl.<init>(SemanticVersionImpl.java:95)
	... 25 more
net.fabricmc.loader.api.VersionParsingException: Could not parse version number component '72>'!
	at net.fabricmc.loader.util.version.SemanticVersionImpl.<init>(SemanticVersionImpl.java:100)
	at net.fabricmc.loader.util.version.SemanticVersionPredicateParser.create(SemanticVersionPredicateParser.java:47)
	at net.fabricmc.loader.util.version.VersionPredicateParser.matches(VersionPredicateParser.java:36)
	at net.fabricmc.loader.metadata.ModDependencyImpl.matches(ModDependencyImpl.java:47)
	at net.fabricmc.loader.discovery.ModResolver.addErrorToList(ModResolver.java:355)
	at net.fabricmc.loader.discovery.ModResolver.findCompatibleSet(ModResolver.java:282)
	at net.fabricmc.loader.discovery.ModResolver.resolve(ModResolver.java:787)
	at net.fabricmc.loader.FabricLoader.setup(FabricLoader.java:211)
	at net.fabricmc.loader.FabricLoader.load(FabricLoader.java:201)
	at net.fabricmc.loader.launch.knot.Knot.init(Knot.java:126)
	at net.fabricmc.loader.launch.knot.KnotClient.main(KnotClient.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)
Caused by: java.lang.NumberFormatException: For input string: "72>"
	at java.lang.NumberFormatException.forInputString(Unknown Source)
	at java.lang.Integer.parseInt(Unknown Source)
	at java.lang.Integer.parseInt(Unknown Source)
	at net.fabricmc.loader.util.version.SemanticVersionImpl.<init>(SemanticVersionImpl.java:95)
	... 18 more
```
</details>