### PR TITLE
Vicuña - Adjusted Fabric Loader dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,6 +31,6 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.12.0"
+    "fabricloader": ">=0.9.0"
   }
 }


### PR DESCRIPTION
[As requested](https://github.com/Chocohead/OptiFabric/pull/804#issuecomment-1218567503), here is a small PR to adjust the Fabric Loader dependency.
Turned out that it was set to high and it actually could support all the way down to Fabric Loader 0.9