### PR TITLE
Add support for Quilt Loader and QSL/QFAPI

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/compat/qslscreenext/mixin/GameRendererMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/qslscreenext/mixin/GameRendererMixin.java
@@ -1,0 +1,48 @@
+package me.modmuss50.optifabric.compat.qslscreenext.mixin;
+
+import me.modmuss50.optifabric.compat.InterceptingMixin;
+import me.modmuss50.optifabric.compat.PlacatingSurrogate;
+import me.modmuss50.optifabric.compat.Shim;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.util.Window;
+import net.minecraft.client.util.math.MatrixStack;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(GameRenderer.class)
+@InterceptingMixin("org/quiltmc/qsl/screen/mixin/client/GameRendererMixin")
+abstract class GameRendererMixin {
+	@Shim
+	private native void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, Matrix4f projection, MatrixStack modelView, MatrixStack matrices);
+
+	@PlacatingSurrogate
+	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack matrices) {
+	}
+
+	@Inject(method = "render(FJZ)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/util/math/MatrixStack;IIF)V", ordinal = 0),
+			locals = LocalCapture.CAPTURE_FAILHARD,
+			cancellable = true)
+	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack modelView, MatrixStack matrices) {
+		onBeforeRenderScreen(tickDelta, startTime, tick, call, mouseX, mouseY, window, projection, modelView, matrices);
+	}
+
+	@Shim
+	private native void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, Matrix4f projection, MatrixStack modelView, MatrixStack matrices);
+
+	@PlacatingSurrogate
+	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack matrices) {
+	}
+
+	@Inject(method = "render(FJZ)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/util/math/MatrixStack;IIF)V", shift = Shift.AFTER, ordinal = 0),
+			locals = LocalCapture.CAPTURE_FAILHARD)
+	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack modelView, MatrixStack matrices) {
+		onAfterRenderScreen(tickDelta, startTime, tick, call, mouseX, mouseY, window, projection, modelView, matrices);
+	}
+}

--- a/src/main/java/me/modmuss50/optifabric/compat/qslscreenext/mixin/GameRendererOldMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/qslscreenext/mixin/GameRendererOldMixin.java
@@ -1,0 +1,48 @@
+package me.modmuss50.optifabric.compat.qslscreenext.mixin;
+
+import me.modmuss50.optifabric.compat.InterceptingMixin;
+import me.modmuss50.optifabric.compat.PlacatingSurrogate;
+import me.modmuss50.optifabric.compat.Shim;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.util.Window;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(GameRenderer.class)
+@InterceptingMixin("org/quiltmc/qsl/screen/mixin/client/GameRendererMixin")
+abstract class GameRendererOldMixin {
+	@Shim
+	private native void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, Matrix4f projection, MatrixStack modelView, MatrixStack matrices);
+
+	@PlacatingSurrogate
+	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack matrices) {
+	}
+
+	@Inject(method = "render(FJZ)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V", ordinal = 0),
+			locals = LocalCapture.CAPTURE_FAILHARD,
+			cancellable = true)
+	private void onBeforeRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack modelView, MatrixStack matrices) {
+		onBeforeRenderScreen(tickDelta, startTime, tick, call, mouseX, mouseY, window, projection, modelView, matrices);
+	}
+
+	@Shim
+	private native void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, Matrix4f projection, MatrixStack modelView, MatrixStack matrices);
+
+	@PlacatingSurrogate
+	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack matrices) {
+	}
+
+	@Inject(method = "render(FJZ)V",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;render(Lnet/minecraft/client/util/math/MatrixStack;IIF)V", shift = Shift.AFTER, ordinal = 0),
+			locals = LocalCapture.CAPTURE_FAILHARD)
+	private void onAfterRenderScreen(float tickDelta, long startTime, boolean tick, CallbackInfo call, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f projection, MatrixStack modelView, MatrixStack matrices) {
+		onAfterRenderScreen(tickDelta, startTime, tick, call, mouseX, mouseY, window, projection, modelView, matrices);
+	}
+}

--- a/src/main/java/me/modmuss50/optifabric/mod/Loader.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/Loader.java
@@ -1,0 +1,54 @@
+package me.modmuss50.optifabric.mod;
+
+import com.google.common.base.MoreObjects;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.VersionParsingException;
+import net.fabricmc.loader.api.metadata.ModMetadata;
+import net.fabricmc.loader.api.metadata.version.VersionPredicate;
+import net.fabricmc.loader.util.version.SemanticVersionImpl;
+import net.fabricmc.loader.util.version.SemanticVersionPredicateParser;
+
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+//Might need this class for other stuff too in the future
+public class Loader {
+    private static final boolean quilt;
+    private static final BiFunction<String, ModMetadata, Boolean> versionCompareFunction;
+
+    static {
+        quilt = FabricLoader.getInstance().isModLoaded("quilt_loader");
+        if (quilt) {
+            versionCompareFunction = (versionRange, mod) -> {
+                try {
+                    return VersionPredicate.parse(versionRange).test(mod.getVersion());
+                } catch (VersionParsingException e) {
+                    System.err.println("Error comparing the version for ".concat(MoreObjects.firstNonNull(mod.getName(), mod.getId())));
+                    e.printStackTrace();
+                    return false; //Let's just gamble on the version not being valid also not being a problem
+                }
+            };
+        } else {
+            versionCompareFunction = (versionRange, mod) -> {
+                try {
+                    Predicate<SemanticVersionImpl> predicate = SemanticVersionPredicateParser.create(versionRange);
+                    SemanticVersionImpl version = new SemanticVersionImpl(mod.getVersion().getFriendlyString(), false);
+                    return predicate.test(version);
+                } catch (@SuppressWarnings("deprecation") net.fabricmc.loader.util.version.VersionParsingException e) {
+                    System.err.println("Error comparing the version for ".concat(MoreObjects.firstNonNull(mod.getName(), mod.getId())));
+                    e.printStackTrace();
+                    return false; //Let's just gamble on the version not being valid also not being a problem
+                }
+            };
+        }
+    }
+
+    public static boolean isQuilt() {
+        return quilt;
+    }
+
+    public static boolean compareVersions(String versionRange, ModMetadata mod) {
+        return versionCompareFunction.apply(versionRange, mod);
+    }
+}
+

--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/HeldItemRendererFix.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/HeldItemRendererFix.java
@@ -1,0 +1,45 @@
+package me.modmuss50.optifabric.patcher.fixes;
+
+import com.google.common.collect.MoreCollectors;
+import me.modmuss50.optifabric.util.RemappingUtils;
+import org.apache.commons.lang3.Validate;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+import java.util.Arrays;
+
+public class HeldItemRendererFix implements ClassFixer {
+    /*
+    Optifine changes multiple ItemStack#isOf calls to instanceof (and some other stuff)
+    which don't affect vanilla behaviour, but mess up a redirect of the
+    aforementioned method. As far as I checked, the only behavioural change
+    Optifine does is introducing a Shader check at the start of the method.
+     */
+    private static final String stitchName = RemappingUtils.getMethodName("class_759", "method_3228", "(Lnet/minecraft/class_742;FFLnet/minecraft/class_1268;FLnet/minecraft/class_1799;FLnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V");
+
+    @Override
+    public void fix(ClassNode optifine, ClassNode minecraft) {
+
+        //Remove the old method
+        optifine.methods.removeIf(methodNode -> methodNode.name.equals(stitchName));
+
+        //Find the vanilla method
+        MethodNode methodNode = minecraft.methods.stream().filter(node -> node.name.equals(stitchName)).collect(MoreCollectors.onlyElement());
+        Validate.notNull(methodNode, "old method null");
+
+        //Add the check optifine does to the original method
+        LabelNode label = (LabelNode) Arrays.stream(methodNode.instructions.toArray()).filter(insn -> insn instanceof LabelNode).findFirst().orElseThrow(() -> new IllegalStateException("No LabelNode?"));
+        InsnList optifineCheck = new InsnList();
+        optifineCheck.add(new LabelNode());
+        optifineCheck.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/optifine/Config", "isShaders", "()Z"));
+        optifineCheck.add(new JumpInsnNode(Opcodes.IFEQ, label));
+        optifineCheck.add(new VarInsnNode(Opcodes.ALOAD, 4));
+        String desc = "(L" + RemappingUtils.getClassName("class_1268") + ";)Z";
+        optifineCheck.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/optifine/shaders/Shaders", "isSkipRenderHand", desc));
+        optifineCheck.add(new JumpInsnNode(Opcodes.IFEQ, label));
+        optifineCheck.add(new InsnNode(Opcodes.RETURN));
+        methodNode.instructions.insert(optifineCheck);
+
+        optifine.methods.add(methodNode);
+    }
+}

--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/OptifineFixer.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/OptifineFixer.java
@@ -43,6 +43,9 @@ public class OptifineFixer {
 		//net/minecraft/client/render/model/json/ModelOverrideList
 		registerFix("class_806", new ModelOverrideListFix());
 
+		//net/minecraft/client/render/item/HeldItemRenderer
+		registerFix("class_759", new HeldItemRendererFix());
+
 		if (FabricLoader.getInstance().isModLoaded("fabric-rendering-fluids-v1")) {
 			//net/minecraft/client/render/block/FluidRenderer
 			registerFix("class_775", new FluidRendererFix());

--- a/src/main/resources/optifabric.compat.qslscreenext.mixins.json
+++ b/src/main/resources/optifabric.compat.qslscreenext.mixins.json
@@ -1,0 +1,8 @@
+{
+	"parent": "optifabric.mixins.json",
+	"package": "me.modmuss50.optifabric.compat.qslscreenext.mixin",
+	"plugin": "me.modmuss50.optifabric.compat.InterceptingMixinPlugin",
+	"mixins": [
+		"GameRendererMixin"
+	]
+}

--- a/src/main/resources/optifabric.compat.qslscreenext.old-mixins.json
+++ b/src/main/resources/optifabric.compat.qslscreenext.old-mixins.json
@@ -1,0 +1,8 @@
+{
+	"parent": "optifabric.mixins.json",
+	"package": "me.modmuss50.optifabric.compat.qslscreenext.mixin",
+	"plugin": "me.modmuss50.optifabric.compat.InterceptingMixinPlugin",
+	"mixins": [
+		"GameRendererOldMixin"
+	]
+}


### PR DESCRIPTION
### Might not be ready for merge

The goal of this PR is to allow players to use Quilt Loader + QSL alongside Optifabric without causing any additional issues compared to using Fabric Loader + Fabric API.

closes #751 and #899

Note: I will be calling Quilt Standard Libraries/Quilted Fabric API the same since, although they are different repos, there exists a [single mod implementation](https://modrinth.com/mod/qsl).

I tested the following versions with Quilt Loader 0.17.11 and 0.18.3 and I haven't encountered any issues:

- 1.19.3 + QSL 4.0.0 + I2_pre5
- 1.19.2 + QSL 3.0.0 + H9
- 1.18.2 + QSL 1.1.0 + H7
- _1.16.5 + FAPI 0.42.0 + G7_
- _1.16.1 + FAPI 0.18.0 + G2_

The versions in _italics_ seem to start _**extremely**_ slowly when using Quilt Loader 0.17.* or 0.16.1. I have not tested all of the loader versions, however it seems the startup is **painfully** slow on anything <0.18.
**QSL exists _only_ for versions >=1.18.2**

### Overcoming issues

1. **Getting the game to start**
The main problem with running Optifabric on Quilt Loader was its reliance on deprecated internal Fabric Loader APIs. By checking if Quilt is present and, if so, not using those internal APIs, this issue can be easily circumvented, allowing the game to start normally.

2. **Getting Quilt Standard Libraries to work**
QSL makes use mostly of Fabric API mixins, so there aren't many issues to fix (in theory at least).

- QSL Screen replaces Fabric's Screen API and as such its `GameRendererMixin` requires its own `InterceptingMixin` due to slightly different `onBeforeRenderScreen` and `onAfterRenderScreen` callback injectors.
- QSL's Item Extension API gets messed up by Optifine changing all instances of `ItemStack.isOf(Items.CROSSBOW)` to `instanceof CrossbowItem` inside the `renderFirstPersonItem` method. `HeldItemRendererFix` replaces the Optifine method with the vanilla one and re-adds Optifine's check `Shaders.isSkipRenderHand` at the head of the method. _As far as I noticed, Optifine doesn't add any other behavioural changes. `HeldItemRendererFix` will run whether or not QSL is present at runtime._
- When checking the version of a Fabric API mod `fabric-x` the version of `quilted_fabric_x` will be returned instead. As such, `OptifabricSetup` will explicitly check if the quilted version of the mod is present, without checking the version, because even the lowest QSL mod version is based on a Fabric API version whose modules satisfy every version check in `OptifabricSetup`