### PR TITLE
Fix architectury 1.19.3

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/compat/architectury/mixin/GameRendererNewerererMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/architectury/mixin/GameRendererNewerererMixin.java
@@ -1,0 +1,47 @@
+package me.modmuss50.optifabric.compat.architectury.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.util.Window;
+import net.minecraft.client.util.math.MatrixStack;
+import org.joml.Matrix4f;
+
+import me.modmuss50.optifabric.compat.InterceptingMixin;
+import me.modmuss50.optifabric.compat.PlacatingSurrogate;
+import me.modmuss50.optifabric.compat.Shim;
+
+@Mixin(GameRenderer.class)
+@InterceptingMixin("dev/architectury/mixin/fabric/client/MixinGameRenderer")
+abstract class GameRendererNewerererMixin {
+    @Shim
+    private native void renderScreenPre(float tickDelta, long startTime, boolean tick, CallbackInfo ci, int mouseX, int mouseY, Window window, Matrix4f matrix, MatrixStack matrices, MatrixStack matrices2);
+
+    @PlacatingSurrogate
+    private void renderScreenPre(float tickDelta, long startTime, boolean tick, CallbackInfo ci, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f matrix, MatrixStack matrices) {
+    }
+
+    @Inject(method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/util/math/MatrixStack;IIF)V", ordinal = 0))
+    private void renderScreenPre(float tickDelta, long startTime, boolean tick, CallbackInfo ci, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f matrix, MatrixStack matrices, MatrixStack matrices2) {
+        renderScreenPre(tickDelta, startTime, tick, ci, mouseX, mouseY, window, matrix, matrices, matrices2);
+    }
+
+    @Shim
+    private native void renderScreenPost(float tickDelta, long startTime, boolean tick, CallbackInfo ci, int mouseX, int mouseY, Window window, Matrix4f matrix, MatrixStack matrices, MatrixStack matrices2);
+
+    @PlacatingSurrogate
+    private void renderScreenPost(float tickDelta, long startTime, boolean tick, CallbackInfo ci, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f matrix, MatrixStack matrices) {
+    }
+
+    @Inject(method = "render(FJZ)V", locals = LocalCapture.CAPTURE_FAILHARD,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderWithTooltip(Lnet/minecraft/client/util/math/MatrixStack;IIF)V", shift = Shift.AFTER, ordinal = 0))
+    private void renderScreenPost(float tickDelta, long startTime, boolean tick, CallbackInfo ci, int mouseX, int mouseY, Window window, float guiFarPlane, Matrix4f matrix, MatrixStack matrices, MatrixStack matrices2) {
+        renderScreenPost(tickDelta, startTime, tick, ci, mouseX, mouseY, window, matrix, matrices, matrices2);
+    }
+}

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -397,7 +397,9 @@ public class OptifabricSetup implements Runnable {
 			Mixins.addConfiguration("optifabric.compat.images.mixins.json");
 		}
 
-		if (isPresent("architectury", ">=3.7")) {
+		if (isPresent("architectury", ">=7.0.52")) {
+			Mixins.addConfiguration("optifabric.compat.architectury-AB.newererer-mixins.json");
+		} else if (isPresent("architectury", ">=3.7")) {
 			Mixins.addConfiguration("optifabric.compat.architectury-AB.newerer-mixins.json");
 		} else if (isPresent("architectury", ">=2.0")) {
 			assert isPresent("minecraft", ">=1.17-beta.1");

--- a/src/main/resources/optifabric.compat.architectury-AB.newererer-mixins.json
+++ b/src/main/resources/optifabric.compat.architectury-AB.newererer-mixins.json
@@ -1,0 +1,8 @@
+{
+    "parent": "optifabric.mixins.json",
+    "package": "me.modmuss50.optifabric.compat.architectury.mixin",
+    "plugin": "me.modmuss50.optifabric.compat.InterceptingMixinPlugin",
+    "mixins": [
+        "GameRendererNewerererMixin"
+    ]
+}


### PR DESCRIPTION
### Regarding the fix
1.19.3 switched to `org.joml.Matrix4f` and the target of `renderScreenPre` and `renderScreenPost` was also changed. Due to the fact that these changes were made in different Architectury API versions, anything strictly below `7.0.59` **will crash** _even though the version range for the new patches is `>=7.0.52`_. While not particularly hard to do so, these crashes should not be fixed.
As far as I checked, Architectury should run just fine on 1.19.2 and the latest 1.19.3 version.

### Regarding the project structure
I think the naming scheme **needs** an overhaul as keeping track of all the files named _Newererer_ is quite difficult. On another note, there _might_ be a way of automatically generating the required Intercepting Mixins at build time, without explicitly creating each one of them, thus requiring less maintenance for compat patches. Furthermore, a fake `LanguageAdapter` class could perform some kind of analysis and intercept mixins based on it.

fixed #978 
fixed #875
fixed #996
_Might be some others but I'm too lazy to check_