### PR TITLE
Fix KeyboardFix for 1.16 and 1.17

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -532,7 +532,7 @@ public class OptifabricSetup implements Runnable {
 		return FabricLoader.getInstance().isModLoaded(modID);
 	}
 
-	static boolean isPresent(String modID, String versionRange) {
+	public static boolean isPresent(String modID, String versionRange) {
 		return isPresent(modID, modMetadata -> compareVersions(versionRange, modMetadata));
 	}
 

--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/KeyboardFix.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/KeyboardFix.java
@@ -1,11 +1,14 @@
 package me.modmuss50.optifabric.patcher.fixes;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
 
+import me.modmuss50.optifabric.mod.OptifabricSetup;
 import org.apache.commons.lang3.Validate;
 
 import org.objectweb.asm.Handle;
@@ -21,17 +24,23 @@ import me.modmuss50.optifabric.util.RemappingUtils;
 
 public class KeyboardFix implements ClassFixer {
 	private final String screenClass = RemappingUtils.getClassName("class_437");
-	private final Set<String> revertMethods = ImmutableSet.of(
-			RemappingUtils.getMethodName("class_309", "method_1466", "(JIIII)V"), //Keyboard, onKey
-			RemappingUtils.getMethodName("class_309", "method_1454", "(IL" + screenClass + ";[ZIII)V"),
-			RemappingUtils.getMethodName("class_309", "method_1458", "(L" + screenClass + ";II)V"),
-			RemappingUtils.getMethodName("class_309", "method_1473", "(L" + screenClass + ";CI)V"),
-			RemappingUtils.getMethodName("class_309", "method_1463", "(Lnet/minecraft/class_2561)V"),
-			RemappingUtils.getMethodName("class_309", "method_1464", "(Lnet/minecraft/class_2561)V")
-	);
+	private Set<String> revertMethods;
 
 	@Override
 	public void fix(ClassNode optifine, ClassNode minecraft) {
+		List<String> revert = new ArrayList<>(Arrays.asList(
+				RemappingUtils.getMethodName("class_309", "method_1466", "(JIIII)V"), //Keyboard, onKey
+				RemappingUtils.getMethodName("class_309", "method_1454", "(IL" + screenClass + ";[ZIII)V"),
+				RemappingUtils.getMethodName("class_309", "method_1463", "(Lnet/minecraft/class_2561)V"),
+				RemappingUtils.getMethodName("class_309", "method_1464", "(Lnet/minecraft/class_2561)V")
+		));
+
+		if (OptifabricSetup.isPresent("minecraft", ">=1.18.2")) {
+			revert.add(RemappingUtils.getMethodName("class_309", "method_1458", "(L" + screenClass + ";II)V"));
+			revert.add(RemappingUtils.getMethodName("class_309", "method_1473", "(L" + screenClass + ";CI)V"));
+		}
+		revertMethods = ImmutableSet.copyOf(revert);
+
 		Validate.noNullElements(revertMethods, "Failed to remap Keyboard method name %d"); //ImmutableSet iteration order is stable
 
 		//Remove the "broken" OptiFine methods


### PR DESCRIPTION
> _As far as I tested this is not an issue, but I am unsure whether or not it will prove to be one in the future._

[Jinxed it](https://github.com/Chocohead/OptiFabric/pull/1002#issuecomment-1475256117)

Both Lambdas (being `method_1458` and `method_1473`) have different Optifine signatures in 1.16 and 1.17 meaning the JVM will hava a stroke when it looks for a bootstrap method with the signature `(Lnet/minecraft/class_309;IILnet/minecraft/class_364;)V` and doesn't find it. Since JEI doesn't exist for any version lower than 1.18.2 not patching these lambdas (or outright replacing them with the vanilla ones) _should **not**_ break anything that wasn't broken before. Just to make sure, I tested the following versions and the game does properly work:

- 1.16.5
- 1.18.2 (with JEI)
- 1.19.2 (with JEI)

fixed #1013
Thank you @akemin-dayo for the detailed reports!