### PR TITLE
Fix Borderless Mining game options menu crash

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/compat/borderlessmining/BorderlessMiningMixinPlugin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/borderlessmining/BorderlessMiningMixinPlugin.java
@@ -23,7 +23,7 @@ public class BorderlessMiningMixinPlugin extends InterceptingMixinPlugin {
 
 			for (MethodNode method : targetClass.methods) {
 				if (init.equals(method.name) && "()V".equals(method.desc)) {
-					Member createSimpleOption = RemappingUtils.mapMethod("class_7172", "<init>", "(Ljava/lang/String;Lnet/minecraft/class_7172$class_7307;Lnet/minecraft/class_7172$class_7303;Lnet/minecraft/class_7172$class_7178;Ljava/lang/Object;Ljava/util/function/Consumer;)V");
+					Member createSimpleOption = RemappingUtils.mapMethod("class_7172", "<init>", getCreateSimpleOptionInitDescriptor());
 					InsnList extra = new InsnList();
 					LabelNode skip = new LabelNode();
 
@@ -38,5 +38,9 @@ public class BorderlessMiningMixinPlugin extends InterceptingMixinPlugin {
 		}
 
 		super.preApply(targetClassName, targetClass, mixinClassName, mixinInfo);
+	}
+
+	protected String getCreateSimpleOptionInitDescriptor() {
+		return "(Ljava/lang/String;Lnet/minecraft/class_7172$class_7307;Lnet/minecraft/class_7172$class_7303;Lnet/minecraft/class_7172$class_7178;Ljava/lang/Object;Ljava/util/function/Consumer;)V";
 	}
 }

--- a/src/main/java/me/modmuss50/optifabric/compat/borderlessmining/BorderlessMiningNewMixinPlugin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/borderlessmining/BorderlessMiningNewMixinPlugin.java
@@ -1,0 +1,8 @@
+package me.modmuss50.optifabric.compat.borderlessmining;
+
+public class BorderlessMiningNewMixinPlugin extends BorderlessMiningMixinPlugin {
+    @Override
+    protected String getCreateSimpleOptionInitDescriptor() {
+        return "(Ljava/lang/String;Lnet/minecraft/class_7172$class_7277;Lnet/minecraft/class_7172$class_7303;Lnet/minecraft/class_7172$class_7178;Ljava/lang/Object;Ljava/util/function/Consumer;)V";
+    }
+}

--- a/src/main/java/me/modmuss50/optifabric/compat/borderlessmining/mixin/OptionFullscreenResolutionNewMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/borderlessmining/mixin/OptionFullscreenResolutionNewMixin.java
@@ -1,0 +1,22 @@
+package me.modmuss50.optifabric.compat.borderlessmining.mixin;
+
+import me.modmuss50.optifabric.compat.borderlessmining.MagicMixinBridge;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.option.VideoOptionsScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Pseudo
+@Mixin(targets = "net.optifine.gui.OptionFullscreenResolution", remap = false)
+abstract class OptionFullscreenResolutionNewMixin {
+	@ModifyArgs(method = "make",
+				at = @At(value = "INVOKE", target = "Lnet/minecraft/class_7172;<init>(Ljava/lang/String;Lnet/minecraft/class_7172$class_7307;Lnet/minecraft/class_7172$class_7277;Lnet/minecraft/class_7172$class_7178;Ljava/lang/Object;Ljava/util/function/Consumer;)V", remap = true))
+	private static void modifyOption(Args args) {
+		Screen screen = MinecraftClient.getInstance().currentScreen;
+		((MagicMixinBridge) (screen instanceof MagicMixinBridge ? screen : new VideoOptionsScreen(screen, MinecraftClient.getInstance().options))).optifabric£modifyFullscreenButton(args);
+	}
+}

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -177,7 +177,7 @@ public class OptifabricSetup implements Runnable {
 
 					for (MethodNode method : node.methods) {
 						if ("renderBatched".equals(method.name) && method.desc.endsWith(desc)) {
-							Mixins.addConfiguration("optifabric.compat.indigo.newer-mixins.json");							
+							Mixins.addConfiguration("optifabric.compat.indigo.newer-mixins.json");
 							return;
 						}
 					}
@@ -235,7 +235,7 @@ public class OptifabricSetup implements Runnable {
 			Mixins.addConfiguration("optifabric.optifine.old-mixins.json");
 		}
 
-        if (isPresent("fabricloader", ">=0.13.0") && (isPresent("cloth-client-events-v0", ">=3.1.58") || isPresent("cloth-client-events-v0", ">=2.1.60 <3.0") || isPresent("cloth-client-events-v0", ">=1.6.59 <2.0"))) {
+		if (isPresent("fabricloader", ">=0.13.0") && (isPresent("cloth-client-events-v0", ">=3.1.58") || isPresent("cloth-client-events-v0", ">=2.1.60 <3.0") || isPresent("cloth-client-events-v0", ">=1.6.59 <2.0"))) {
 			// no mixins are needed -- cloth had a workaround for https://github.com/FabricMC/Mixin/issues/80
 			// but it is now fixed in fabricloader
 		} else if (isPresent("cloth-client-events-v0", ">=2.0")) {
@@ -377,7 +377,7 @@ public class OptifabricSetup implements Runnable {
 						}
 					}
 				});
-			}	
+			}
 		} else if (isPresent("charm", ">=3.0 <4.0")) {
 			Mixins.addConfiguration("optifabric.compat.charm.mixins.json");
 		} else if (isPresent("charm", ">=4.0")) {
@@ -510,7 +510,9 @@ public class OptifabricSetup implements Runnable {
 			Mixins.addConfiguration("optifabric.compat.zoomify.mixins.json");
 		}
 
-		if (isPresent("borderlessmining", ">=1.1.3")) {
+		if (isPresent("borderlessmining", ">=1.1.6")) {
+			Mixins.addConfiguration("optifabric.compat.borderlessmining.new-mixins.json");
+		} else if (isPresent("borderlessmining", ">=1.1.3")) {
 			Mixins.addConfiguration("optifabric.compat.borderlessmining.mixins.json");
 		}
 

--- a/src/main/resources/optifabric.compat.borderlessmining.new-mixins.json
+++ b/src/main/resources/optifabric.compat.borderlessmining.new-mixins.json
@@ -1,0 +1,9 @@
+{
+	"parent": "optifabric.mixins.json",
+	"package": "me.modmuss50.optifabric.compat.borderlessmining.mixin",
+	"plugin": "me.modmuss50.optifabric.compat.borderlessmining.BorderlessMiningNewMixinPlugin",
+	"mixins": [
+		"VideoOptionsScreenMixin",
+		"OptionFullscreenResolutionNewMixin"
+	]
+}


### PR DESCRIPTION
Both Optifine and Borderless Mining rely on `TooltipFactory` instead of `TooltipFactoryGetter` in 1.19.3 and up since the latter class got removed in this version. Fixing this is simple (just use the new class instead of the old one), although it requires those pesky `New` Mixins, MixinPlugins and Mixin Configurations. This time I made sure to test the patch before creating the PR so bad code doesn't get merged [like last time](https://github.com/Chocohead/OptiFabric/issues/1013) due to me just hoping it doesn't break stuff in older versions:

- 1.16.5 (BM 1.0.6 & FAPI 0.42.0)
- 1.18.2 (FAPI 0.75.1)
- 1.19 (BM 1.1.5 & FAPI 0.58.0)
- 1.19.3 (BM 1.1.6 & FAPI 0.76.0)
- 1.19.4 (BM 1.1.7 & FAPI 0.76.0)


fixed #1015