### PR TITLE
Fix Language Reload >=1.5.0

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -532,7 +532,7 @@ public class OptifabricSetup implements Runnable {
 		return FabricLoader.getInstance().isModLoaded(modID);
 	}
 
-	static boolean isPresent(String modID, String versionRange) {
+	public static boolean isPresent(String modID, String versionRange) {
 		return isPresent(modID, modMetadata -> compareVersions(versionRange, modMetadata));
 	}
 

--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/GameOptionsFix.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/GameOptionsFix.java
@@ -1,0 +1,51 @@
+package me.modmuss50.optifabric.patcher.fixes;
+
+import com.google.common.collect.MoreCollectors;
+import me.modmuss50.optifabric.util.RemappingUtils;
+import org.apache.commons.lang3.Validate;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+public class GameOptionsFix implements ClassFixer {
+
+    private final String gameOptionsName = RemappingUtils.getClassName("class_315");
+    private final String loadName = RemappingUtils.getMethodName("class_315", "method_1636", "()V");
+
+    @Override
+    public void fix(ClassNode optifine, ClassNode minecraft) {
+        optifine.methods.removeIf(method -> loadName.equals(method.name));
+        optifine.methods.removeIf(method -> "load".equals(method.name));
+        //lambda$load(NbtCompound,String)void
+        optifine.methods.removeIf(method -> (method.access | Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC) == method.access
+                        && method.name.startsWith("lambda$load$")
+                        && method.desc.equals(RemappingUtils.mapMethodDescriptor("(Lnet/minecraft/class_2487;Ljava/lang/String;)V")));
+
+        MethodNode method = minecraft.methods.stream().filter(node -> loadName.equals(node.name)).collect(MoreCollectors.onlyElement());
+        Validate.notNull(method, "old method null");
+
+        MethodNode lambda = minecraft.methods.stream().filter(node -> "method_24230".equals(node.name)).collect(MoreCollectors.onlyElement());
+        Validate.notNull(method, "old method lambda null");
+
+        //re-add the Optifine stuff
+        InsnList head = new InsnList();
+        head.add(new VarInsnNode(Opcodes.ALOAD, 0));
+        head.add(new InsnNode(Opcodes.ICONST_1));
+        head.add(new FieldInsnNode(Opcodes.PUTFIELD, gameOptionsName, "loadOptions", "Z"));
+
+        InsnList tail = new InsnList();
+        tail.add(new VarInsnNode(Opcodes.ALOAD, 0));
+        tail.add(new InsnNode(Opcodes.ICONST_0));
+        tail.add(new FieldInsnNode(Opcodes.PUTFIELD, gameOptionsName, "loadOptions", "Z"));
+        tail.add(new VarInsnNode(Opcodes.ALOAD, 0));
+        tail.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, gameOptionsName, "loadOfOptions", "()V", false));
+
+        method.instructions.insertBefore(method.instructions.getFirst(), head);
+        method.instructions.insertBefore(method.instructions.getLast().getPrevious(), tail);
+
+        optifine.methods.add(method);
+        //failsafe for 1.18.2
+        if (optifine.methods.stream().noneMatch(node -> node.name.equals(lambda.name) && node.desc.equals(lambda.desc))) {
+            optifine.methods.add(lambda);
+        }
+    }
+}

--- a/src/main/java/me/modmuss50/optifabric/patcher/fixes/OptifineFixer.java
+++ b/src/main/java/me/modmuss50/optifabric/patcher/fixes/OptifineFixer.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import me.modmuss50.optifabric.mod.OptifabricSetup;
 import net.fabricmc.loader.api.FabricLoader;
 
 import me.modmuss50.optifabric.compat.fabricrenderingfluids.FluidRendererFix;
@@ -42,6 +43,11 @@ public class OptifineFixer {
 
 		//net/minecraft/client/render/model/json/ModelOverrideList
 		registerFix("class_806", new ModelOverrideListFix());
+
+		if (OptifabricSetup.isPresent("minecraft", ">=1.18.2")) {
+			//net/minecraft/client/option/GameOptions
+			registerFix("class_315", new GameOptionsFix());
+		}
 
 		if (FabricLoader.getInstance().isModLoaded("fabric-rendering-fluids-v1")) {
 			//net/minecraft/client/render/block/FluidRenderer


### PR DESCRIPTION
The `ClassFixer`  is only active in 1.18.2 and up since Language Reload 1.5.0+ only exists for these versions. Optifine does something like this:

```JAVA
// added by optfine
private boolean loadOptions;

// vanilla method
public void load() {
    // body changed by optifine
    // only called here
    load(false);
}

// added by optifine
public void load(boolean limited) {
    this.loadOptions = true;
    // vanilla behavior
    ... // lambda is called somewhere here
    this.loadOptions = false;
    this.loadOfOptions();
}

public void loadOfOptions() {
    // optifine stuff
}

// name changed from method_24230
private static synthetic void lambda$load$105(NbtCompound nbt, String string) {
    // vanilla stuff
}
```

I tested the following versions:

- 1.18.2 (FAPI 0.76.0 + LR 1.5.4)
- 1.19 (FAPI 0.58.0)
- 1.19.2 (FAPI 0.75.1)
- 1.19.3 (FAPI 0.76.0 + LR 1.5.6)
- 1.19.4 (FAPI 0.76.0 + LR 1.5.5)
- 1.16.5 _the patch shouldn't even be applied_

fixed #1014