### PR TITLE
Fix Carpet 1.19.3-1.20.1

### DIFF
--- a/src/main/java/me/modmuss50/optifabric/compat/carpet/mixin/LevelRendererExtraNewMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/carpet/mixin/LevelRendererExtraNewMixin.java
@@ -1,0 +1,23 @@
+package me.modmuss50.optifabric.compat.carpet.mixin;
+
+import me.modmuss50.optifabric.compat.InterceptingMixin;
+import me.modmuss50.optifabric.compat.Shim;
+import net.minecraft.client.render.WorldRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(WorldRenderer.class)
+@InterceptingMixin("carpet/mixins/LevelRenderer_pausedShakeMixin")
+abstract class LevelRendererExtraNewMixin {
+    @ModifyVariable(method = "render(Lnet/minecraft/client/util/math/MatrixStack;FJZLnet/minecraft/client/render/Camera;Lnet/minecraft/client/render/GameRenderer;Lnet/minecraft/client/render/LightmapTextureManager;Lorg/joml/Matrix4f;)V", argsOnly = true, ordinal = 0, require = 3, allow = 3,
+                    at = @At(value = "INVOKE",
+                                target = "Lnet/minecraft/client/particle/ParticleManager;render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider$Immediate;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/client/render/Camera;FLnet/minecraft/client/render/Frustum;)V",
+                                shift = At.Shift.BEFORE))
+    private float doNewChangeTickPhaseBack(float previous) {
+        return changeTickPhaseBack(previous);
+    }
+
+    @Shim
+    private native float changeTickPhaseBack(float previous);
+}

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -327,8 +327,10 @@ public class OptifabricSetup implements Runnable {
 				Mixins.addConfiguration("optifabric.compat.carpet.mixins.json");
 			}
 
-			if (particlesPresent.getAsBoolean() && isPresent("<1.19.3")) {
-				if (isPresent("minecraft", ">=1.18.2")) {
+			if (particlesPresent.getAsBoolean()) {
+				if (isPresent("minecraft", ">=1.19.3")) {
+					Mixins.addConfiguration("optifabric.compat.carpet.extra-newer-mixins.json");
+				} else if (isPresent("minecraft", ">=1.18.2")) {
 					Mixins.addConfiguration("optifabric.compat.carpet.extra-new-mixins.json");
 				} else {
 					Mixins.addConfiguration("optifabric.compat.carpet.extra-mixins.json");

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -327,7 +327,7 @@ public class OptifabricSetup implements Runnable {
 				Mixins.addConfiguration("optifabric.compat.carpet.mixins.json");
 			}
 
-			if (particlesPresent.getAsBoolean()) {
+			if (particlesPresent.getAsBoolean() && isPresent("<1.19.3")) {
 				if (isPresent("minecraft", ">=1.18.2")) {
 					Mixins.addConfiguration("optifabric.compat.carpet.extra-new-mixins.json");
 				} else {

--- a/src/main/resources/optifabric.compat.carpet.extra-newer-mixins.json
+++ b/src/main/resources/optifabric.compat.carpet.extra-newer-mixins.json
@@ -1,0 +1,8 @@
+{
+    "parent": "optifabric.mixins.json",
+    "package": "me.modmuss50.optifabric.compat.carpet.mixin",
+    "plugin": "me.modmuss50.optifabric.compat.carpet.CarpetExtraMixinPlugin",
+    "mixins": [
+        "LevelRendererExtraNewMixin"
+    ]
+}


### PR DESCRIPTION
As far as I've tested `InterceptingMixin`'s don't need to be used in 1.19.3 and above.
Tested the following versions:
- 1.19.2 Optifine H9 & I2 FAPI 0.75.1
- 1.19.3 Optifine I3 FAPI 0.76.0
- 1.19.4 Optifine I4 FAPI 0.85.0
- 1.20 Optifine I5 pre5 FAPI 0.83.0
- 1.20.1 Optifine I5 FAPI 0.85.0

fixes #1115 fixes #1104 fixes #1043 fixes #1029 fixes #1010 fixes #1146

Edit: The first commit can be completely ignored, its only purpose being to allow the game to start in 1.19.3+ without fixing the underlying issue.