### PR TITLE
Fix Fabric API 0.86.0+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ compileJava {
 		classes += ['net/minecraft/class_5944': 'net/minecraft/class_5944']
 		method 'net/minecraft/class_5944', '(Lnet/minecraft/class_5912;Lnet/minecraft/util/Identifier;Lnet/minecraft/client/render/VertexFormat;)V', '<init>', '<init>'
 		method 'net/minecraft/client/gui/screen/Screen', '(Lnet/minecraft/class_332;IIF)V', 'renderWithTooltip', 'method_47413'
+		classes += ['net/minecraft/client/render/model/Baker': 'net/minecraft/class_7775']
 	}
 }
 

--- a/src/main/java/me/modmuss50/optifabric/compat/fabricmodelloadingapi/ModelLoadingMixinPlugin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/fabricmodelloadingapi/ModelLoadingMixinPlugin.java
@@ -1,0 +1,93 @@
+package me.modmuss50.optifabric.compat.fabricmodelloadingapi;
+
+import me.modmuss50.optifabric.compat.InterceptingMixinPlugin;
+import me.modmuss50.optifabric.util.MixinUtils;
+import me.modmuss50.optifabric.util.RemappingUtils;
+import net.fabricmc.tinyremapper.IMappingProvider.Member;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.transformer.ClassInfo;
+
+public class ModelLoadingMixinPlugin extends InterceptingMixinPlugin {
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        // not doing this will cause Mixin to have a stroke while trying to find where to put the fabric injectors
+        ClassInfo info = ClassInfo.forName(targetClassName);
+        MixinUtils.completeClassInfo(info, targetClass.methods);
+        String bakeDesc = "(Lnet/minecraft/class_2960;Lnet/minecraft/class_3665;)Lnet/minecraft/class_1087;";//(Identifier, ModelBakeSettings)BakedModel
+        String bake = RemappingUtils.getMethodName("class_7775", "method_45873", bakeDesc);//BakerImpl, bake
+        bakeDesc = RemappingUtils.mapMethodDescriptor(bakeDesc);
+        if ("ModelLoaderBakerImplMixin".equals(mixinInfo.getName())) {
+            for (MethodNode method : targetClass.methods) {
+                if (bake.equals(method.name) && bakeDesc.equals(method.desc)) {
+                    //This is the @ModifyVariable
+                    //target = "Lnet/minecraft/client/render/model/ModelLoader$BakerImpl;getOrLoadModel(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/model/UnbakedModel;"
+                    Member mfMixinTarget = RemappingUtils.mapMethod("class_1088$class_7778", "method_45872", "(Lnet/minecraft/class_2960;)Lnet/minecraft/class_1100;");
+                    LabelNode fakeStart = new LabelNode();
+                    LabelNode skip = new LabelNode();
+                    InsnList extraFirst = new InsnList();
+
+                    /*
+                    The following line doesn't work because why would it work (it does in OriginMixinPlugin)
+                    so I have to resort to using postApply and remove this trash code
+                     */
+//                    extra.add(new JumpInsnNode(Opcodes.GOTO, skip));
+                    extraFirst.add(fakeStart);
+                    extraFirst.add(new InsnNode(Opcodes.ACONST_NULL));
+                    extraFirst.add(new InsnNode(Opcodes.ACONST_NULL));
+                    extraFirst.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, mfMixinTarget.owner, mfMixinTarget.name, mfMixinTarget.desc));
+                    extraFirst.add(new VarInsnNode(Opcodes.ASTORE, 3));
+                    extraFirst.add(skip);
+
+                    method.localVariables.add(new LocalVariableNode("fakeUnbakedModel", "L" + RemappingUtils.getClassName("class_1087") + ";", null, fakeStart, skip, 3));
+                    method.instructions.insertBefore(method.instructions.getFirst(), extraFirst);
+                    method.maxLocals += 1;
+
+                    //This part takes care of the two @Redirect
+                    //target = "Lnet/minecraft/client/render/model/UnbakedModel;bake(Lnet/minecraft/client/render/model/Baker;Ljava/util/function/Function;Lnet/minecraft/client/render/model/ModelBakeSettings;Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/model/BakedModel;"
+                    Member redirectMixinTarget1 = RemappingUtils.mapMethod("class_1100", "method_4753", "(Lnet/minecraft/class_7775;Ljava/util/function/Function;Lnet/minecraft/class_3665;Lnet/minecraft/class_2960;)Lnet/minecraft/class_1087;");
+                    //target = "Lnet/minecraft/client/render/model/json/JsonUnbakedModel;bake(Lnet/minecraft/client/render/model/Baker;Lnet/minecraft/client/render/model/json/JsonUnbakedModel;Ljava/util/function/Function;Lnet/minecraft/client/render/model/ModelBakeSettings;Lnet/minecraft/util/Identifier;Z)Lnet/minecraft/client/render/model/BakedModel;"
+                    Member redirectMixinTarget2 = RemappingUtils.mapMethod("class_793", "method_3446", "(Lnet/minecraft/class_7775;Lnet/minecraft/class_793;Ljava/util/function/Function;Lnet/minecraft/class_3665;Lnet/minecraft/class_2960;Z)Lnet/minecraft/class_1087;");
+                    LabelNode skipLast = new LabelNode();
+                    InsnList extraLast = new InsnList();
+                    // this works because funny (and because no local variable is involved)
+                    extraLast.add(new JumpInsnNode(Opcodes.GOTO, skipLast));
+                    extraLast.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, redirectMixinTarget1.owner, redirectMixinTarget1.name, redirectMixinTarget1.desc));
+                    extraLast.add(new MethodInsnNode(Opcodes.INVOKEINTERFACE, redirectMixinTarget2.owner, redirectMixinTarget2.name, redirectMixinTarget2.desc));
+                    extraLast.add(skipLast);
+                    method.instructions.insertBefore(method.instructions.getLast(), extraLast);
+                    break;
+                }
+            }
+        }
+
+        super.preApply(targetClassName, targetClass, mixinClassName, mixinInfo);
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+        String bakeDesc = "(Lnet/minecraft/class_2960;Lnet/minecraft/class_3665;)Lnet/minecraft/class_1087;";
+        String bake = RemappingUtils.getMethodName("class_7775", "method_45873", bakeDesc);
+        bakeDesc = RemappingUtils.mapMethodDescriptor(bakeDesc);
+
+        if ("ModelLoaderBakerImplMixin".equals(mixinInfo.getName())) {
+            out: for (MethodNode method : targetClass.methods) {
+                if (bake.equals(method.name) && bakeDesc.equals(method.desc)) {
+                    LocalVariableNode fakeUnbakedModel = method.localVariables.get(3);
+                    method.localVariables.remove(fakeUnbakedModel);
+                    method.maxLocals -= 1;
+                    // remove trash
+                    for (AbstractInsnNode insn : method.instructions) {
+                        method.instructions.remove(insn);
+                        System.out.println(insn);
+                        if (fakeUnbakedModel.end.equals(insn)) {
+                            break out;
+                        }
+                    }
+                }
+            }
+        }
+        super.postApply(targetClassName, targetClass, mixinClassName, mixinInfo);
+    }
+}

--- a/src/main/java/me/modmuss50/optifabric/compat/fabricmodelloadingapi/mixin/ModelLoaderBakerImplMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/compat/fabricmodelloadingapi/mixin/ModelLoaderBakerImplMixin.java
@@ -1,0 +1,48 @@
+package me.modmuss50.optifabric.compat.fabricmodelloadingapi.mixin;
+
+import me.modmuss50.optifabric.compat.InterceptingMixin;
+import me.modmuss50.optifabric.compat.Shim;
+import net.minecraft.class_7775;
+import net.minecraft.client.render.model.BakedModel;
+import net.minecraft.client.render.model.ModelBakeSettings;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.JsonUnbakedModel;
+import net.minecraft.client.texture.Sprite;
+import net.minecraft.client.util.SpriteIdentifier;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Function;
+
+@Mixin(targets = "net/minecraft/class_1088$class_7778")
+@InterceptingMixin("net/fabricmc/fabric/mixin/client/model/loading/ModelLoaderBakerImplMixin")
+abstract class ModelLoaderBakerImplMixin {
+    @Shim private native UnbakedModel invokeModifyBeforeBake(UnbakedModel model, Identifier id, ModelBakeSettings settings);
+
+    @ModifyVariable(method = "bake", remap = false,
+            at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/class_1088$class_7778;method_45872(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/model/UnbakedModel;", remap = true))
+    private UnbakedModel invokeModifyBeforeBake(UnbakedModel model, Identifier id, ModelBakeSettings settings, Function<?, ?> sprites) {
+        return invokeModifyBeforeBake(model, id, settings);
+    }
+
+    @Shim
+    private native BakedModel invokeModifyAfterBake(UnbakedModel unbakedModel, class_7775 baker, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Identifier id);
+
+    @Redirect(method = "bake", remap = false,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/UnbakedModel;method_4753(Lnet/minecraft/client/render/model/Baker;Ljava/util/function/Function;Lnet/minecraft/client/render/model/ModelBakeSettings;Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/model/BakedModel;", remap = true))
+    private BakedModel optifabric_invokeModifyAfterBake(UnbakedModel unbakedModel, class_7775 baker, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Identifier id) {
+        return invokeModifyAfterBake(unbakedModel, baker, textureGetter, settings, id);
+    }
+
+
+    @Shim private native BakedModel invokeModifyAfterBake(JsonUnbakedModel unbakedModel, class_7775 baker, JsonUnbakedModel parent, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Identifier id, boolean hasDepth);
+
+    @Redirect(method = "bake", remap = false,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/json/JsonUnbakedModel;method_3446(Lnet/minecraft/client/render/model/Baker;Lnet/minecraft/client/render/model/json/JsonUnbakedModel;Ljava/util/function/Function;Lnet/minecraft/client/render/model/ModelBakeSettings;Lnet/minecraft/util/Identifier;Z)Lnet/minecraft/client/render/model/BakedModel;", remap = true))
+    private BakedModel optifabric_invokeModifyAfterBake(JsonUnbakedModel unbakedModel, class_7775 baker, JsonUnbakedModel parent, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings settings, Identifier id, boolean hasDepth) {
+        return invokeModifyAfterBake(unbakedModel, baker, parent, textureGetter, settings, id, hasDepth);
+    }
+}

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -234,6 +234,10 @@ public class OptifabricSetup implements Runnable {
 			Mixins.addConfiguration("optifabric.compat.fabric-lifecycle-events.new-mixins.json");
 		}
 
+		if (isPresent("fabric-model-loading-api-v1")) {
+			Mixins.addConfiguration("optifabric.compat.fabric-model-loading-api.mixins.json");
+		}
+
 		Mixins.addConfiguration("optifabric.optifine.mixins.json");
 		if (OptifabricSetup.isPresent("minecraft", "<=1.19.2")) {
 			Mixins.addConfiguration("optifabric.optifine.old-mixins.json");

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifineSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifineSetup.java
@@ -272,6 +272,10 @@ public class OptifineSetup {
 		ClassDef builtChunk = nameToClass.get("net/minecraft/class_846$class_851");
 		extraFields.put(new Member(rebuildTask.getName(from), "this$1", 'L' + builtChunk.getName(from) + ';'), "field_20839");
 
+		ClassDef bakerImpl = nameToClass.get("net/minecraft/class_1088$class_7778");
+		ClassDef modelLoader = nameToClass.get("net/minecraft/class_1088");
+		extraFields.put(new Member(bakerImpl.getName(from), "this$0", 'L' + modelLoader.getName(from) + ';'), "field_40571");
+
 		ClassDef particleManager = nameToClass.get("net/minecraft/class_702");
 		particleManager.getFields().stream().filter(field -> "field_3835".equals(field.getName("intermediary"))).forEach(field -> {
 			extraFields.put(new Member(particleManager.getName(from), field.getName(from), "Ljava/util/Map;"), field.getName(to));

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifineSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifineSetup.java
@@ -273,8 +273,10 @@ public class OptifineSetup {
 		extraFields.put(new Member(rebuildTask.getName(from), "this$1", 'L' + builtChunk.getName(from) + ';'), "field_20839");
 
 		ClassDef bakerImpl = nameToClass.get("net/minecraft/class_1088$class_7778");
-		ClassDef modelLoader = nameToClass.get("net/minecraft/class_1088");
-		extraFields.put(new Member(bakerImpl.getName(from), "this$0", 'L' + modelLoader.getName(from) + ';'), "field_40571");
+		if (bakerImpl != null) {//Only present in 1.19.3+
+			ClassDef modelLoader = nameToClass.get("net/minecraft/class_1088");
+			extraFields.put(new Member(bakerImpl.getName(from), "this$0", 'L' + modelLoader.getName(from) + ';'), "field_40571");
+		}
 
 		ClassDef particleManager = nameToClass.get("net/minecraft/class_702");
 		particleManager.getFields().stream().filter(field -> "field_3835".equals(field.getName("intermediary"))).forEach(field -> {

--- a/src/main/resources/optifabric.compat.fabric-model-loading-api.mixins.json
+++ b/src/main/resources/optifabric.compat.fabric-model-loading-api.mixins.json
@@ -1,0 +1,8 @@
+{
+  "parent": "optifabric.mixins.json",
+  "package": "me.modmuss50.optifabric.compat.fabricmodelloadingapi.mixin",
+  "plugin": "me.modmuss50.optifabric.compat.fabricmodelloadingapi.ModelLoadingMixinPlugin",
+  "mixins": [
+    "ModelLoaderBakerImplMixin"
+  ]
+}

--- a/src/shim/java/net/minecraft/class_7775.java
+++ b/src/shim/java/net/minecraft/class_7775.java
@@ -1,0 +1,4 @@
+package net.minecraft;
+
+public interface class_7775 {
+}


### PR DESCRIPTION
### Superseded by #1201

### Quick note:
If the Optifine cache in the `.optifine` folder already exists, the [new mappings](https://github.com/Chocohead/OptiFabric/compare/llama...XXMA16:fapi-fix?expand=1#diff-da5bb78a5f5a8071fd9e26c20bdbeff23b0f9e6d8e124403eea464b2000b7397R275-R278) will *not* take effect. The easiest way of fixing this is manually deleting the `.optifine` folder. Users will likely expect the game to work properly if they update to a version with the changelog *Fixed Fabric API 0.86.0+* without having to do any additional stuff, making this a slight issue.
**This still applies after the second commit!**

### Testing
Fabric API introduced the Model Loading API in version 0.86.0 and since the new mixin config takes effect *only* when that module is present it **should not** break anything that wasn't broken already. As such I did minimal testing _edit:_ **bad idea, everything that _can_ go wrong _will_ go wrong**, the ~only configuration~ configurations that I know ~is~ are working properly being:
- 1.20.1 I5 FAPI 0.86.1 _was the only one tested initially_
- 1.19.2 I2 FAPI 0.76.0
- 1.19.3 I3 FAPI 0.76.0
- 1.19.4 I4 FAPI 0.76.0
- 1.19.4 I4 FAPI 0.87.0

by "working" I mean the following:
- the game launches properly
- resource packs aren't bugged (see #1123)
- the fabric mixins get applied correctly (`-Dmixin.debug.export=true` classes confirms this)

### Regarding the fix itself:
I was not able to get the Intercepting Mixin Plugin working without also messing with stuff in `postApply()` (as evidenced by my saltiness [here](https://github.com/Chocohead/OptiFabric/compare/llama...XXMA16:fapi-fix?expand=1#diff-f370c840d4fe2715b8b1a8b43efe87b0249b8a60d866e41e2fa012d17e99cdd2R32-R33)) due to Mixin complaining about `InvalidImplicitDiscriminatorException` (even though I *think* I followed the same principle applied in `OriginMixinPlugin`). On top of that, Mixin would also throw the same exception if I tried to put the fake calls (with or without some `ACONST_NULL`s and `POP`s) before the other instructions of the vanilla `bake` method (thus I resorted to using two `InsnList`s). The other stuff is pretty straight-forward, even though it took me pretty long to understand that `@Shim`ming methods does not also solve the issue of Mixin not finding the target and that has to be dealt with manually (because reading is hard). On a side note, half the problems I encountered when writing the fix consisted of me writing wrong descriptors and the other half of my bad understanding of Optifabric's codebase (if we exclude that damned `@ModifyVariable` which I still don't understand why it's so picky).

#### Fixed issues
fixes #1123 fixes #1124 fixes #1127 fixes #1134 fixes #1136 fixes #1139 fixes #1151 fixes #1153 fixes #1156 fixes #1157 fixes #1161 fixes #1166 fixes #1169 fixes #1172 fixes #1177 fixes #1181 fixes #1182 fixes #1183 fixes #1184 fixes #1185 fixes #1186 fixes #1187 fixes #1188 fixes #1189

Please merge or at least consider merging #94 because the repo's issues page is full of duplicates, vague issues, the occasional _why doesn't this work with sodium_, etc.

