### PR TITLE
Fix OptiFine's Connected Textures in 1.19.3+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,17 +5,20 @@ buildscript {
 			url = 'https://maven.fabricmc.net/'
 		}
 		mavenCentral()
-		maven { 
+		gradlePluginPortal()
+		maven {
 			name = "Jitpack"
 			url 'https://jitpack.io/'
 		}
 	}
 	dependencies {
 		classpath 'com.github.Chocohead.Fabric-Loom:fabric-loom:0d0261a'
+		classpath 'com.github.johnrengelman:shadow:7.1.2'
 	}
 }
 
 apply plugin: net.fabricmc.loom.LoomGradlePlugin
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'maven-publish'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -40,7 +43,11 @@ dependencies {
 	modImplementation "com.github.Chocohead:Fabric-ASM:${project.fabric_asm_version}"
 	include "com.github.Chocohead:Fabric-ASM:${project.fabric_asm_version}"
 
-	include(modImplementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.2.0-rc.2")))
+	shadow(annotationProcessor("io.github.llamalad7:mixinextras-common:${project.mixinextras_version}"))
+}
+
+configurations {
+	implementation.extendsFrom shadow
 }
 
 sourceSets {
@@ -116,6 +123,17 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 jar {
 	from "LICENSE"
+}
+
+shadowJar {
+	configurations = [project.configurations.shadow]
+	relocate("com.llamalad7.mixinextras", "me.modmuss50.optifabric.mixinextras")
+	mergeServiceFiles()
+}
+
+remapJar {
+	dependsOn(shadowJar)
+	input.set(shadowJar.archiveFile)
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
 	modImplementation "com.github.Chocohead:Fabric-ASM:${project.fabric_asm_version}"
 	include "com.github.Chocohead:Fabric-ASM:${project.fabric_asm_version}"
+
+	include(modImplementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.2.0-rc.2")))
 }
 
 sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ loader_version=0.12.5
 
 fabric_version=0.42.0+1.16
 fabric_asm_version=v2.3
+mixinextras_version=0.2.0-rc.5
 
 mod_version = 1.13.25
 maven_group = me.modmuss50

--- a/src/main/java/me/modmuss50/optifabric/mixin/DefaultResourcePackMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/mixin/DefaultResourcePackMixin.java
@@ -1,0 +1,29 @@
+package me.modmuss50.optifabric.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.modmuss50.optifabric.mod.OptifineResources;
+import net.minecraft.resource.DefaultResourcePack;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Mixin(value = DefaultResourcePack.class, priority = 400)
+abstract class DefaultResourcePackMixin {
+	@Dynamic
+	@WrapOperation(method = {"findInputStream", "getResourceOF"}, at = @At(value = "INVOKE", target = "Lnet/optifine/reflect/ReflectorForge;getOptiFineResourceStream(Ljava/lang/String;)Ljava/io/InputStream;"), require = 1, allow = 1)
+	private InputStream doFindResource(String pathStr, Operation<InputStream> original) {
+		try {
+			InputStream stream = OptifineResources.INSTANCE.getResource(pathStr);
+			if (stream != null) return stream;
+		} catch (IOException e) {
+			//Optifine does this if it goes wrong so we will too
+			//It doesn't in later versions (should revisit this sometime in the future)
+			e.printStackTrace();
+		}
+		return original.call(pathStr);
+	}
+}

--- a/src/main/java/me/modmuss50/optifabric/mixin/DefaultResourcePackOldMixin.java
+++ b/src/main/java/me/modmuss50/optifabric/mixin/DefaultResourcePackOldMixin.java
@@ -1,8 +1,5 @@
 package me.modmuss50.optifabric.mixin;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -16,22 +13,9 @@ import net.minecraft.util.Identifier;
 import me.modmuss50.optifabric.mod.OptifineResources;
 
 @Mixin(value = DefaultResourcePack.class, priority = 400)
-abstract class MixinDefaultResourcePack {
+abstract class DefaultResourcePackOldMixin {
 	@Shadow
 	private static native String getPath(ResourceType type, Identifier id);
-
-	@Inject(method = "findInputStream", at = @At("HEAD"), cancellable = true)
-	protected void onFindInputStream(ResourceType type, Identifier id, CallbackInfoReturnable<InputStream> callback) {
-		String path = getPath(type, id);
-
-		try {
-			InputStream stream = OptifineResources.INSTANCE.getResource(path);
-			if (stream != null) callback.setReturnValue(stream);
-		} catch (IOException e) {
-			//Optifine does this if it goes wrong so we will too
-			e.printStackTrace();
-		}
-	}
 
 	@Inject(method = "contains", at = @At("HEAD"), cancellable = true)
 	public void doesContain(ResourceType type, Identifier id, CallbackInfoReturnable<Boolean> callback) {

--- a/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
+++ b/src/main/java/me/modmuss50/optifabric/mod/OptifabricSetup.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.MoreObjects;
 
+import com.llamalad7.mixinextras.MixinExtrasBootstrap;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.objectweb.asm.ClassWriter;
@@ -41,6 +42,8 @@ public class OptifabricSetup implements Runnable {
 	//This is called early on to allow us to get the transformers in beofore minecraft starts
 	@Override
 	public void run() {
+		MixinExtrasBootstrap.init();
+
 		OptifineInjector injector;
 		try {
 			Pair<File, ClassCache> runtime = OptifineSetup.getRuntime();

--- a/src/main/resources/optifabric.optifine.mixins.json
+++ b/src/main/resources/optifabric.optifine.mixins.json
@@ -4,6 +4,7 @@
 	"mixins": [
 		"MixinReflectorClass",
 		"MixinOptifineConfig",
+		"DefaultResourcePackMixin",
 		"CustomColoursMixin",
 		"ShadersMixin",
 		"VideoOptionsScreenMixin",

--- a/src/main/resources/optifabric.optifine.old-mixins.json
+++ b/src/main/resources/optifabric.optifine.old-mixins.json
@@ -2,6 +2,6 @@
 	"parent": "optifabric.optifine.mixins.json",
 	"package": "me.modmuss50.optifabric.mixin",
 	"mixins": [
-		"MixinDefaultResourcePack"
+		"DefaultResourcePackOldMixin"
 	]
 }


### PR DESCRIPTION
Since 8193335 made it so that the old DefaultResourcePack mixin isn't loaded in 1.19.3+ (because of Minecraft's changes), but didn't add a replacement, CTM textures won't load properly in versions strictly higher than 1.19.2.

The fix relies on [MixinExtras](https://github.com/LlamaLad7/MixinExtras) since the code is less clunky that way. I can remove the dependency, but I though it might also be useful in the future.

There are a few problems with using MixinExtras though: if another mod uses version 0.1.1 and initializes it in a MixinConfigPlugin, against LlamaLad's [advice](https://github.com/LlamaLad7/MixinExtras#footnotes) the game will crash if the Loader version is strictly below 0.12.0. This shouldn't happen however, since other mods that depend on MixinExtras are also expected to depend on Fabric Loader >=0.14.11.

The second commit ensures that under normal circumstances the game is able to start with any Fabric Loader >=0.8.

fixes #1218 fixes #1164 fixes #1149 fixes #1107 fixes #1089 fixes #1036 fixes #1011 fixes #980
Might fix #1220 fix #1208 fix #1203